### PR TITLE
add editing option

### DIFF
--- a/ar-aberturas/lib/stock/stock-options.ts
+++ b/ar-aberturas/lib/stock/stock-options.ts
@@ -61,6 +61,20 @@ export async function createOption<T>(
 	return { data, error };
 }
 
+export async function updateOption<T>(
+	table: string,
+	id: number,
+	item: Partial<T>
+): Promise<{ data: T | null; error: any }> {
+	const supabase = getSupabaseClient();
+	const { data, error } = await supabase
+		.from(table)
+		.update(item as any)
+		.eq('id', id)
+		.select('*');
+	return { data: data && data.length > 0 ? (data[0] as T) : null, error };
+}
+
 export async function deleteOption(
 	table: string,
 	id: number,

--- a/ar-aberturas/utils/stock/options/option-add.tsx
+++ b/ar-aberturas/utils/stock/options/option-add.tsx
@@ -25,6 +25,7 @@ import {
 } from '@/components/ui/select';
 import {
 	createOption,
+	updateOption,
 	type LineOption,
 	CodeOption,
 	ColorOption,
@@ -41,6 +42,7 @@ interface OptionFormDialogProps {
 	triggerButton?: boolean;
 	materialType?: 'Aluminio' | 'PVC';
 	table?: 'lines' | 'codes' | 'colors' | 'sites';
+	editingItem?: LineOption | CodeOption | ColorOption | SiteOption | null;
 }
 
 export function OptionDialog({
@@ -50,6 +52,7 @@ export function OptionDialog({
 	onSave,
 	triggerButton = true,
 	materialType = 'Aluminio',
+	editingItem = null,
 }: OptionFormDialogProps) {
 	const [option, setOption] = useState('');
 	const [dependence, setDependence] = useState('');
@@ -57,31 +60,62 @@ export function OptionDialog({
 	const [title, setTitle] = useState('');
 	const [name, setName] = useState('');
 	const [optionName, setOptionName] = useState('');
+	const isEditing = !!editingItem;
 
 	React.useEffect(() => {
 		if (table === 'lines') {
-			setTitle('Agregar Linea');
+			setTitle(isEditing ? 'Editar Línea' : 'Agregar Linea');
 			setName('Nombre de la línea');
+			setOptionName('Línea');
 		} else if (table === 'codes') {
-			setTitle('Agregar Código');
+			setTitle(isEditing ? 'Editar Código' : 'Agregar Código');
 			setName('Nombre del código');
+			setOptionName('Código');
 		} else if (table === 'colors') {
-			setTitle('Agregar Color');
+			setTitle(isEditing ? 'Editar Color' : 'Agregar Color');
 			setName('Nombre del color');
+			setOptionName('Color');
 		} else if (table === 'sites') {
-			setTitle('Agregar Ubicación');
+			setTitle(isEditing ? 'Editar Ubicación' : 'Agregar Ubicación');
 			setName('Nombre de la ubicación');
+			setOptionName('Ubicación');
 		} else {
-			setTitle('Agregar opción');
+			setTitle(isEditing ? 'Editar opción' : 'Agregar opción');
 		}
-	}, [table]);
+	}, [table, isEditing]);
 
-	// Set default value for 'Abertura' select when dialog opens for lines
+	// Load existing data into form when editing, or clear form when creating new
 	React.useEffect(() => {
-		if (open && table === 'lines') {
+		if (open && isEditing) {
+			if (table === 'lines' && 'name_line' in editingItem) {
+				setOption(editingItem.name_line);
+				setDependence(editingItem.opening);
+			} else if (table === 'codes' && 'name_code' in editingItem) {
+				setOption(editingItem.name_code);
+				setDependence(editingItem.line_name);
+			} else if (table === 'colors' && 'name_color' in editingItem) {
+				setOption(editingItem.name_color);
+				setDependence(editingItem.line_name);
+			} else if (table === 'sites' && 'name_site' in editingItem) {
+				setOption(editingItem.name_site);
+			}
+		} else if (open && !isEditing) {
+			// Clear form when opening for new option
+			setOption('');
+			if (table === 'lines') {
+				setDependence(materialType || 'Aluminio');
+			} else {
+				setDependence('');
+			}
+		}
+	}, [open, editingItem, isEditing, table, materialType]);
+
+	// Set default value for 'Abertura' select when dialog opens for lines (solo si no es edición)
+	React.useEffect(() => {
+		if (open && table === 'lines' && !isEditing) {
 			setDependence(materialType || 'Aluminio');
 		}
-	}, [open, table, materialType]);
+	}, [open, table, materialType, isEditing]);
 
 	const handleSave = async () => {
 		if (!option) {
@@ -102,32 +136,52 @@ export function OptionDialog({
 			fields.name_line = option ?? '';
 			fields.opening = dependence ?? '';
 			fieldName = 'línea';
-			successMessage = 'Línea guardada correctamente';
+			successMessage = isEditing ? 'Línea actualizada correctamente' : 'Línea guardada correctamente';
 			setOptionName('Linea');
 		} else if (tableName === 'codes') {
 			fields.name_code = option ?? '';
 			fields.line_name = dependence ?? '';
 			fieldName = 'código';
-			successMessage = 'Código guardado correctamente';
+			successMessage = isEditing ? 'Código actualizado correctamente' : 'Código guardado correctamente';
 			setOptionName('Código');
 		} else if (tableName === 'colors') {
 			fields.name_color = option ?? '';
 			fields.line_name = dependence ?? '';
 			fieldName = 'color';
-			successMessage = 'Color guardado correctamente';
+			successMessage = isEditing ? 'Color actualizado correctamente' : 'Color guardado correctamente';
 			setOptionName('Color');
 		} else if (tableName === 'sites') {
 			fields.name_site = option ?? '';
 			fieldName = 'ubicación';
-			successMessage = 'Ubicación guardada correctamente';
+			successMessage = isEditing ? 'Ubicación actualizada correctamente' : 'Ubicación guardada correctamente';
 			setOptionName('Ubicación');
 		}
-		const { data, error } = await createOption(tableName ?? '', fields);
+
+		let data: any = null;
+		let error: any = null;
+
+		if (isEditing && editingItem && 'id' in editingItem) {
+			// Modo edición - actualizar los campos editados
+			const result = await updateOption(tableName ?? '', editingItem.id, fields);
+			data = result.data;
+			error = result.error;
+
+			// Si no hay error pero tampoco data, usamos los datos editados
+			if (!error && !data) {
+				data = { ...editingItem, ...fields };
+			}
+		} else {
+			// Mode creation
+			const result = await createOption(tableName ?? '', fields);
+			data = result.data;
+			error = result.error;
+		}
+
 		if (error) {
 			console.error('Supabase error:', error);
 			let errorMessage = translateError(error);
 			toast({
-				title: 'Error al guardar',
+				title: isEditing ? 'Error al actualizar' : 'Error al guardar',
 				description: errorMessage,
 				variant: 'destructive',
 				duration: 5000,
@@ -163,8 +217,10 @@ export function OptionDialog({
 
 			<DialogContent showCloseButton={false} className="bg-card max-h-[90vh] flex flex-col">
 				<DialogHeader className="flex-shrink-0">
-					<DialogTitle>Agregar nueva opción</DialogTitle>
-					<DialogDescription>Ingrese los datos</DialogDescription>
+					<DialogTitle>{isEditing ? 'Editar opción' : 'Agregar nueva opción'}</DialogTitle>
+					<DialogDescription>
+						{isEditing ? 'Actualice los datos' : 'Ingrese los datos'}
+					</DialogDescription>
 				</DialogHeader>
 
 				<div className="overflow-y-auto flex-1 py-4 pr-2 -mr-2">
@@ -216,7 +272,7 @@ export function OptionDialog({
 						Cancelar
 					</Button>
 					<Button onClick={handleSave} className="w-full sm:w-auto">
-						Guardar
+						{isEditing ? 'Actualizar' : 'Guardar'}
 					</Button>
 				</DialogFooter>
 			</DialogContent>

--- a/ar-aberturas/utils/stock/options/options.tsx
+++ b/ar-aberturas/utils/stock/options/options.tsx
@@ -18,7 +18,7 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from '@/components/ui/dialog';
-import { ChevronDown, ChevronUp, Trash2 } from 'lucide-react';
+import { ChevronDown, ChevronUp, Trash2, Edit } from 'lucide-react';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { OptionDialog } from './option-add';
 import { toast } from '@/components/ui/use-toast';
@@ -46,6 +46,12 @@ export function OptionsModal({ materialType, open, onOpenChange }: OptionsModalP
 	const [isAddColorOpen, setIsAddColorOpen] = useState(false);
 	const [isAddCodeOpen, setIsAddCodeOpen] = useState(false);
 	const [isAddSiteOpen, setIsAddSiteOpen] = useState(false);
+
+	// States for editing options
+	const [editingLine, setEditingLine] = useState<LineOption | null>(null);
+	const [editingCode, setEditingCode] = useState<CodeOption | null>(null);
+	const [editingColor, setEditingColor] = useState<ColorOption | null>(null);
+	const [editingSite, setEditingSite] = useState<SiteOption | null>(null);
 
 	// Estados para controlar qué secciones están abiertas
 	const [openSections, setOpenSections] = useState({
@@ -217,7 +223,7 @@ export function OptionsModal({ materialType, open, onOpenChange }: OptionsModalP
 										<tr className="border-b">
 											<th className="text-left p-1">Linea</th>
 											<th className="text-left p-1">Abertura</th>
-											<th className="text-center p-1">Eliminar</th>
+											<th className="text-center p-1">Acciones</th>
 										</tr>
 									</thead>
 									<tbody>
@@ -226,21 +232,29 @@ export function OptionsModal({ materialType, open, onOpenChange }: OptionsModalP
 												<td className="p-1">{line.name_line}</td>
 												<td className="p-1">{line.opening}</td>
 												<td className="p-1 text-center">
-													<Button
-														variant="ghost"
-														size="icon"
-														className="mx-auto"
-														onClick={() =>
-															setDeleteDialog({
-																open: true,
-																table: 'lines',
-																id: line.id,
-																label: line.name_line ?? '',
-															})
-														}
-													>
-														<Trash2 className="w-4 h-4 text-destructive" />
-													</Button>
+													<div className="flex gap-2 justify-center">
+														<Button
+															variant="ghost"
+															size="icon"
+															onClick={() => setEditingLine(line)}
+														>
+															<Edit className="w-4 h-4 text-primary" />
+														</Button>
+														<Button
+															variant="ghost"
+															size="icon"
+															onClick={() =>
+																setDeleteDialog({
+																	open: true,
+																	table: 'lines',
+																	id: line.id,
+																	label: line.name_line ?? '',
+																})
+															}
+														>
+															<Trash2 className="w-4 h-4 text-destructive" />
+														</Button>
+													</div>
 												</td>
 											</tr>
 										))}
@@ -287,7 +301,7 @@ export function OptionsModal({ materialType, open, onOpenChange }: OptionsModalP
 										<tr className="border-b">
 											<th className="text-left p-1">Código</th>
 											<th className="text-left p-1">Línea</th>
-											<th className="text-center p-1">Eliminar</th>
+											<th className="text-center p-1">Acciones</th>
 										</tr>
 									</thead>
 									<tbody>
@@ -296,21 +310,29 @@ export function OptionsModal({ materialType, open, onOpenChange }: OptionsModalP
 												<td className="p-1">{code.name_code}</td>
 												<td className="p-1">{code.line_name}</td>
 												<td className="p-1 text-center">
-													<Button
-														variant="ghost"
-														size="icon"
-														className="mx-auto"
-														onClick={() =>
-															setDeleteDialog({
-																open: true,
-																table: 'codes',
-																id: code.id,
-																label: code.name_code ?? '',
-															})
-														}
-													>
-														<Trash2 className="w-4 h-4 text-destructive" />
-													</Button>
+													<div className="flex gap-2 justify-center">
+														<Button
+															variant="ghost"
+															size="icon"
+															onClick={() => setEditingCode(code)}
+														>
+															<Edit className="w-4 h-4 text-primary" />
+														</Button>
+														<Button
+															variant="ghost"
+															size="icon"
+															onClick={() =>
+																setDeleteDialog({
+																	open: true,
+																	table: 'codes',
+																	id: code.id,
+																	label: code.name_code ?? '',
+																})
+															}
+														>
+															<Trash2 className="w-4 h-4 text-destructive" />
+														</Button>
+													</div>
 												</td>
 											</tr>
 										))}
@@ -357,7 +379,7 @@ export function OptionsModal({ materialType, open, onOpenChange }: OptionsModalP
 										<tr className="border-b">
 											<th className="text-left p-1">Color</th>
 											<th className="text-left p-1">Línea</th>
-											<th className="text-center p-1">Eliminar</th>
+											<th className="text-center p-1">Acciones</th>
 										</tr>
 									</thead>
 									<tbody>
@@ -366,21 +388,29 @@ export function OptionsModal({ materialType, open, onOpenChange }: OptionsModalP
 												<td className="p-1">{color.name_color}</td>
 												<td className="p-1">{color.line_name}</td>
 												<td className="p-1 text-center">
-													<Button
-														variant="ghost"
-														size="icon"
-														className="mx-auto"
-														onClick={() =>
-															setDeleteDialog({
-																open: true,
-																table: 'colors',
-																id: color.id,
-																label: color.name_color ?? '',
-															})
-														}
-													>
-														<Trash2 className="w-4 h-4 text-destructive" />
-													</Button>
+													<div className="flex gap-2 justify-center">
+														<Button
+															variant="ghost"
+															size="icon"
+															onClick={() => setEditingColor(color)}
+														>
+															<Edit className="w-4 h-4 text-primary" />
+														</Button>
+														<Button
+															variant="ghost"
+															size="icon"
+															onClick={() =>
+																setDeleteDialog({
+																	open: true,
+																	table: 'colors',
+																	id: color.id,
+																	label: color.name_color ?? '',
+																})
+															}
+														>
+															<Trash2 className="w-4 h-4 text-destructive" />
+														</Button>
+													</div>
 												</td>
 											</tr>
 										))}
@@ -425,7 +455,7 @@ export function OptionsModal({ materialType, open, onOpenChange }: OptionsModalP
 									<thead>
 										<tr className="border-b">
 											<th className="text-left p-1">Ubicación</th>
-											<th className="text-center p-1">Eliminar</th>
+											<th className="text-center p-1">Acciones</th>
 										</tr>
 									</thead>
 									<tbody>
@@ -433,21 +463,29 @@ export function OptionsModal({ materialType, open, onOpenChange }: OptionsModalP
 											<tr key={`${site.id}-${site.name_site}`} className="border-b">
 												<td className="p-1">{site.name_site}</td>
 												<td className="p-1 text-center">
-													<Button
-														variant="ghost"
-														size="icon"
-														className="mx-auto"
-														onClick={() =>
-															setDeleteDialog({
-																open: true,
-																table: 'sites',
-																id: site.id,
-																label: site.name_site ?? '',
-															})
-														}
-													>
-														<Trash2 className="w-4 h-4 text-destructive" />
-													</Button>
+													<div className="flex gap-2 justify-center">
+														<Button
+															variant="ghost"
+															size="icon"
+															onClick={() => setEditingSite(site)}
+														>
+															<Edit className="w-4 h-4 text-primary" />
+														</Button>
+														<Button
+															variant="ghost"
+															size="icon"
+															onClick={() =>
+																setDeleteDialog({
+																	open: true,
+																	table: 'sites',
+																	id: site.id,
+																	label: site.name_site ?? '',
+																})
+															}
+														>
+															<Trash2 className="w-4 h-4 text-destructive" />
+														</Button>
+													</div>
 												</td>
 											</tr>
 										))}
@@ -457,6 +495,77 @@ export function OptionsModal({ materialType, open, onOpenChange }: OptionsModalP
 						</CollapsibleContent>
 					</Collapsible>
 				</div>
+
+				{/* AlertDialog for delete option */}
+				{/* Edit Dialogs for options */}
+				<OptionDialog
+					open={!!editingLine}
+					onOpenChange={(open) => {
+						if (!open) setEditingLine(null);
+					}}
+					materialType={materialType}
+					onSave={async (option) => {
+						const updated = lines
+							.map((l) => (l.id === editingLine?.id ? (option as LineOption) : l))
+							.sort((a, b) => a.name_line.localeCompare(b.name_line));
+						localStorage.setItem('lines', JSON.stringify(updated));
+						updateLines(updated);
+						setEditingLine(null);
+					}}
+					triggerButton={false}
+					table="lines"
+					editingItem={editingLine}
+				/>
+
+				<OptionDialog
+					open={!!editingCode}
+					onOpenChange={(open) => {
+						if (!open) setEditingCode(null);
+					}}
+					onSave={async (option) => {
+						const updated = codes.map((c) => (c.id === editingCode?.id ? (option as CodeOption) : c));
+						localStorage.setItem('codes', JSON.stringify(updated));
+						updateCodes(updated);
+						setEditingCode(null);
+					}}
+					triggerButton={false}
+					table="codes"
+					materialType={materialType}
+					editingItem={editingCode}
+				/>
+
+				<OptionDialog
+					open={!!editingColor}
+					onOpenChange={(open) => {
+						if (!open) setEditingColor(null);
+					}}
+					onSave={async (option) => {
+						const updated = colors.map((c) => (c.id === editingColor?.id ? (option as ColorOption) : c));
+						localStorage.setItem('colors', JSON.stringify(updated));
+						updateColors(updated);
+						setEditingColor(null);
+					}}
+					triggerButton={false}
+					table="colors"
+					materialType={materialType}
+					editingItem={editingColor}
+				/>
+
+				<OptionDialog
+					open={!!editingSite}
+					onOpenChange={(open) => {
+						if (!open) setEditingSite(null);
+					}}
+					onSave={async (option) => {
+						const updated = sites.map((s) => (s.id === editingSite?.id ? (option as SiteOption) : s));
+						localStorage.setItem('sites', JSON.stringify(updated));
+						updateSites(updated);
+						setEditingSite(null);
+					}}
+					triggerButton={false}
+					table="sites"
+					editingItem={editingSite}
+				/>
 
 				{/* AlertDialog for delete option */}
 				<AlertDialog


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now edit existing stock options including lines, codes, colors, and sites within the options management modal interface
  * Edit action buttons are now available alongside delete buttons across all options tables for streamlined option management
  * When editing an option, the dialog automatically pre-fills with current values and updates the item upon save instead of creating a new one

<!-- end of auto-generated comment: release notes by coderabbit.ai -->