### PR TITLE
Disabled send email button

### DIFF
--- a/ar-aberturas/utils/works/work-card.tsx
+++ b/ar-aberturas/utils/works/work-card.tsx
@@ -170,6 +170,7 @@ export function WorkCard({
 								<Button
 									variant="outline"
 									size="sm"
+									disabled={true}
 									onClick={() => onOpenEmail(work)}
 									title="Enviar notificación por email"
 								>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The Email notification button now appears disabled, preventing users from selecting an unavailable action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->